### PR TITLE
Explicitely provides the Java version maven should use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
     </properties>
 
     <build>


### PR DESCRIPTION
- It makes builds reproducible
- Without it, when I try `mvn compile` on a fresh clone, I have errors like

> Base64.java:[15,29] generics are not supported in -source 1.3

Note: I'm quite new to Maven, so don't hesitate to tell me if I'm missing some subtleties.
