### PR TITLE
Improve date parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,11 @@ as a module to yours. So you will always stay up to date with the library.
 
 ### Compile it as library
 
-The library itself is a NetBeans project and can be compiled either with NetBeans or
-with `ant`. The resulting JAR file can be used as a dependency in your project. If you
-use NetBeans you can make a dependency directly to the project.
+aXMLRPC uses gradle, so you can build it using
+
+    ./gradlew jar
 
 ### Use Maven
-
-The library is also a valid Maven project. So you can use Maven to compile it.
-If you want to use it as a Maven project in NetBeans, you will have to delete
-the `nbproject` folder. Afterwards NetBeans will detect it as a Maven project (NetBeans
-restart required).
 
 To use it on your Maven project, add it as a dependency on your pom.xml file:
 
@@ -46,13 +41,8 @@ To use it on your Maven project, add it as a dependency on your pom.xml file:
     <version>X.Y.Z</version>
 </dependency>
 ```
-    
-where X.Y.Z is the current aXMLRPC version and install it on your local Maven 
-repository (since it's not available on the Maven repositories):
 
-```console
-$ cd /path/to/aXMLRPC/
-$ mvn clean install
+where X.Y.Z is the current aXMLRPC version
 ```
 
 ### Download the JAR library

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,16 @@ artifacts {
 	archives javadocJar
 }
 
+repositories {
+      mavenLocal()
+      mavenCentral()
+}
+
+
+dependencies {
+    testCompile "junit:junit:4.12"
+}
+
 def sonatypeProps = 'sonatype.properties'
 
 if(project.hasProperty(sonatypeProps) && new File(project.property(sonatypeProps)).exists()) {

--- a/src/main/java/de/timroes/axmlrpc/serializer/DateTimeSerializer.java
+++ b/src/main/java/de/timroes/axmlrpc/serializer/DateTimeSerializer.java
@@ -1,11 +1,14 @@
 package de.timroes.axmlrpc.serializer;
 
+import java.text.SimpleDateFormat;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.w3c.dom.Element;
+
 import de.timroes.axmlrpc.XMLRPCException;
 import de.timroes.axmlrpc.XMLUtil;
 import de.timroes.axmlrpc.xmlcreator.XmlElement;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import org.w3c.dom.Element;
 
 /**
  *
@@ -15,15 +18,34 @@ public class DateTimeSerializer implements Serializer {
 
 	private static final String DATETIME_FORMAT = "yyyyMMdd'T'HH:mm:ss";
 	private static final SimpleDateFormat DATE_FORMATER = new SimpleDateFormat(DATETIME_FORMAT);
+	private static final Pattern PATTERN_WITHOUT_COLON = Pattern.compile("(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+\\d{2})(\\d{2})");
+	private static final Pattern PATTERN_LEGACY = Pattern.compile("(\\d{4})(\\d{2})(\\d{2}T\\d{2}:\\d{2}:\\d{2})");
 
+	@Override
 	public Object deserialize(Element content) throws XMLRPCException {
 		try {
-			return DATE_FORMATER.parse(XMLUtil.getOnlyTextContent(content.getChildNodes()));
-		} catch (ParseException ex) {
+			String value = formatStringIfNeeded(XMLUtil.getOnlyTextContent(content.getChildNodes()));
+			return javax.xml.bind.DatatypeConverter.parseDateTime(value).getTime();
+		} catch (Exception ex) {
 			throw new XMLRPCException("Unable to parse given date.", ex);
 		}
 	}
 
+	private static String formatStringIfNeeded(String dateStr){
+		Matcher matcherWithoutColon = PATTERN_WITHOUT_COLON.matcher(dateStr);
+		if ( matcherWithoutColon.matches() ){
+			return matcherWithoutColon.group(1) + ":" + matcherWithoutColon.group(2);
+		}
+
+		Matcher matcherLegacy = PATTERN_LEGACY.matcher(dateStr);
+		if ( matcherLegacy.matches() ){
+			return matcherLegacy.group(1) + "-" + matcherLegacy.group(2) + "-" + matcherLegacy.group(3);
+		}
+
+		return dateStr;
+	}
+
+	@Override
 	public XmlElement serialize(Object object) {
 		return XMLUtil.makeXmlTag(SerializerHandler.TYPE_DATETIME,
 				DATE_FORMATER.format(object));

--- a/src/main/java/de/timroes/axmlrpc/serializer/DateTimeSerializer.java
+++ b/src/main/java/de/timroes/axmlrpc/serializer/DateTimeSerializer.java
@@ -23,8 +23,12 @@ public class DateTimeSerializer implements Serializer {
 
 	@Override
 	public Object deserialize(Element content) throws XMLRPCException {
+		return deserialize(XMLUtil.getOnlyTextContent(content.getChildNodes()));
+	}
+
+	public Object deserialize(String dateStr) throws XMLRPCException {
 		try {
-			String value = formatStringIfNeeded(XMLUtil.getOnlyTextContent(content.getChildNodes()));
+			String value = formatStringIfNeeded(dateStr);
 			return javax.xml.bind.DatatypeConverter.parseDateTime(value).getTime();
 		} catch (Exception ex) {
 			throw new XMLRPCException("Unable to parse given date.", ex);

--- a/src/test/java/de/timroes/axmlrpc/serializer/TestDateTimeSerializer.java
+++ b/src/test/java/de/timroes/axmlrpc/serializer/TestDateTimeSerializer.java
@@ -1,0 +1,33 @@
+package de.timroes.axmlrpc.serializer;
+
+import static org.junit.Assert.*;
+
+import java.util.Date;
+
+public class TestDateTimeSerializer {
+	private static final Date EXPECTED_DATE = new Date(85, 2, 4, 12, 13, 14);
+
+	@org.junit.Test
+	public void canParseLegacyDates() throws Exception {
+		Date date = (Date) new DateTimeSerializer().deserialize("19850304T12:13:14");
+		assertDatesCloseEnough(EXPECTED_DATE, date);
+	}
+
+	@org.junit.Test
+	public void canParseDateWithoutSemiColon() throws Exception {
+		Date date = (Date) new DateTimeSerializer().deserialize("1985-03-04T12:13:14+0100");
+		assertDatesCloseEnough(EXPECTED_DATE, date);
+	}
+
+	@org.junit.Test
+	public void canParseDateWithSemiColon() throws Exception {
+		Date date = (Date) new DateTimeSerializer().deserialize("1985-03-04T12:13:14+01:00");
+		assertDatesCloseEnough(EXPECTED_DATE, date);
+	}
+
+	//Because I don't want the tests to fail if the user isn't in my timezone
+	private void assertDatesCloseEnough(Date expected, Date actual){
+		long differenceInMs = Math.abs(expected.getTime() - actual.getTime());
+		assertTrue(differenceInMs < 24 * 60 * 60 * 1000);
+	}
+}


### PR DESCRIPTION
With this patch, it's now possible to parse those valid dates:
    
* 2014-11-10T23:38:51+0000
* 2014-11-10T23:38:51+00:00
    
Admittedly, the patch is rather messy. The idea comes from
http://stackoverflow.com/a/2202300/1796345 and the regexes have been used to
handle a few cases that didn't work out of the box.
    
I chose this messy code over using Joda time, since an advantage of aXMLRPC,
is that is has no dependencies

I also took the opportunity to update the README, since it seemed a bit outdated to me